### PR TITLE
🔍 Use OCR-D spelling

### DIFF
--- a/ocrd_butler/database/models.py
+++ b/ocrd_butler/database/models.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""OCRD Butler database models."""
+"""OCR-D Butler database models."""
 
 from ocrd_butler.database import db
 from ocrd_butler.util import to_json

--- a/ocrd_butler/examples/nginx.conf
+++ b/ocrd_butler/examples/nginx.conf
@@ -1,4 +1,4 @@
-# Server configuration for the OCRD Butler (beta).
+# Server configuration for the OCR-D Butler (beta).
 
 server {
   listen 80;


### PR DESCRIPTION
The OCR-D project uses - as far as I can see - the hyphenated "OCR-D"
spelling in normal text. Use this where appropiate.