### PR TITLE
🐛 README: Fix Calamari model for ocrd_calamari >= 1.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ can be overwritten it every single task.
 .. code-block:: bash
 
   > mkdir /data/calamari_models && cd /data/calamari_models
-  > wget https://qurator-data.de/calamari-models/GT4HistOCR/model.tar.xz
+  > wget https://qurator-data.de/calamari-models/GT4HistOCR/2019-12-11T11_10+0100/model.tar.xz
   > tar xf model.tar.xz
 
 * ocrd_tesserocr


### PR DESCRIPTION
The download URL for the Calamari GT4HistOCR model in the README is an
old one, for Calamari 0.3.x. Fix this by updating to the current one.